### PR TITLE
Added caching of less files

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -3,3 +3,9 @@ Requirements::set_backend(new LessCompiler());
 
 /* Add default ThemeDir variable */
 LessCompiler::addVariable('ThemeDir', '"' . Director::baseURL() . SSViewer::get_theme_folder() . '"');
+
+/* Set default cache directory */
+LessCompiler::setCacheDir(Director::baseFolder() . '/' . SSViewer::get_theme_folder() . '/.tmp/less');
+
+/* Set default cache method */
+LessCompiler::setCacheMethod('serialize');


### PR DESCRIPTION
Css is regenerated only when any of less files (also @import -ed) are changed.
So in 'dev' mode, you don't have to wait every request anymore (our time in not free:).

You can still clear cache and force regeneration of css by ?flush.
